### PR TITLE
doc: warn that publish bypasses tag validation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -237,6 +237,8 @@ wokhei delete <event-id-1> <event-id-2> <event-id-3>
 
 ## Raw Event Publishing
 
+> **Warning**: `publish` passes tags through **verbatim with no validation**. Incorrect tag formats (wrong `z` values, missing `names` plural, combined `recommended` fields, etc.) will be published as-is. Prefer `create-header` and `add-item` which enforce correct DCoSL tag structure automatically.
+
 For custom events not covered by built-in commands:
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a warning to SKILL.md's "Raw Event Publishing" section clarifying that `publish` passes tags through verbatim with no validation
- Agents should prefer `create-header` and `add-item` which enforce correct DCoSL tag structure automatically
- Closes #1 (names tag) and #2 (z-tag) — both were caused by raw/manual event construction, not CLI bugs

## Test plan
- [x] `cargo nextest run` — 85/85 pass
- [x] Issues #1 and #2 commented and closed with investigation details

🤖 Generated with [Claude Code](https://claude.com/claude-code)