### PR TITLE
ci: add sem semantic diff to pre-commit and PR review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+language: en-US
+reviews:
+  request_changes_workflow: false
+  high_level_summary: true
+  path_instructions:
+    - path: "**/*.rs"
+      instructions: |
+        Prefer functional/iterator style over imperative loops (iter, map, filter, fold, collect).
+        Avoid mutable variables where possible; favor expression-oriented code.
+        Minimize side effects; keep functions pure.
+        Use combinator chains over for loops with mut accumulators.
+chat:
+  auto_reply: true

--- a/.github/workflows/sem-review.yml
+++ b/.github/workflows/sem-review.yml
@@ -1,0 +1,78 @@
+name: Semantic Diff Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_RETRY: 10
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  sem-diff:
+    name: Semantic Diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          prefix-key: sem
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgit2-dev
+
+      - name: Install sem
+        run: |
+          git clone --depth 1 https://github.com/Ataraxy-Labs/sem /tmp/sem
+          cargo install --path /tmp/sem/crates/sem-cli
+
+      - name: Run semantic diff
+        id: sem
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          DIFF_OUTPUT=$(sem diff --from "$BASE_SHA" --to "$HEAD_SHA" --file-exts .rs 2>&1 || true)
+          JSON_OUTPUT=$(sem diff --from "$BASE_SHA" --to "$HEAD_SHA" --file-exts .rs --format json 2>&1 || true)
+
+          # Check for deleted entities
+          DELETED=""
+          if echo "$JSON_OUTPUT" | jq -e '.changes[]? | select(.kind == "deleted")' > /dev/null 2>&1; then
+            DELETED=$(echo "$JSON_OUTPUT" | jq -r '[.changes[] | select(.kind == "deleted") | "- ⊖ \(.entity_type) `\(.name)`"] | join("\n")' 2>/dev/null || true)
+          fi
+
+          {
+            echo "diff<<SEMEOF"
+            echo "$DIFF_OUTPUT"
+            echo "SEMEOF"
+            echo "deleted<<DEOF"
+            echo "$DELETED"
+            echo "DEOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        if: steps.sem.outputs.diff != ''
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: sem-diff
+          message: |
+            ## Semantic Diff
+
+            Entity-level changes detected by [`sem`](https://github.com/Ataraxy-Labs/sem):
+
+            ```
+            ${{ steps.sem.outputs.diff }}
+            ```
+
+            ${{ steps.sem.outputs.deleted != '' && format('### ⚠️ Deleted Entities\n\n{0}', steps.sem.outputs.deleted) || '' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,12 @@ repos:
         pass_filenames: false
         always_run: true
         priority: 1
+
+      - id: sem-diff
+        name: sem diff (semantic changes)
+        language: system
+        entry: bash -c 'sem diff --staged --file-exts .rs || true'
+        pass_filenames: false
+        always_run: true
+        verbose: true
+        priority: 2

--- a/justfile
+++ b/justfile
@@ -47,3 +47,20 @@ changelog:
 # Dry-run publish check
 publish-check:
     cargo publish --dry-run
+
+# Install development tools (sem, etc.)
+setup-tools:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+    git clone --depth 1 https://github.com/Ataraxy-Labs/sem "$TMPDIR/sem"
+    cargo install --path "$TMPDIR/sem/crates/sem-cli"
+
+# Semantic diff of current branch vs main
+sem-diff:
+    sem diff --from main --to HEAD --file-exts .rs
+
+# Semantic diff (JSON output)
+sem-diff-json:
+    sem diff --from main --to HEAD --file-exts .rs --format json


### PR DESCRIPTION
## Summary

- Add `sem` (entity-level Rust diffs) as an advisory pre-commit hook showing semantic changes on staged `.rs` files
- Add `sem-review.yml` CI workflow that posts a sticky PR comment with the semantic diff summary, highlighting deleted entities
- Add `.coderabbit.yaml` with project Rust style rules (functional/iterator style, no mutable vars)
- Add justfile recipes: `setup-tools` (install sem), `sem-diff`, `sem-diff-json`

## Test plan

- [x] `pre-commit run sem-diff --all-files` passes locally
- [x] `zizmor --no-online-audits .` passes with no findings
- [ ] Verify `sem-review.yml` workflow runs on this PR and posts a comment
- [ ] Verify CodeRabbit activates with the `.coderabbit.yaml` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)